### PR TITLE
Change the way the network module deals with unknown and missing interfaces 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = lib/xpp
 	url = https://github.com/polybar/xpp
 	branch = master
+[submodule "polybar-scripts"]
+	path = polybar-scripts
+	url = https://github.com/polybar/polybar-scripts

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ A fast and easy-to-use tool for creating status bars.
 </p>
 
 <p align="center">
-<a href="https://github.com/polybar/polybar/releases"><img src="https://img.shields.io/github/release/polybar/polybar.svg"></a>
-<a href="https://travis-ci.com/polybar/polybar"><img src="https://travis-ci.com/polybar/polybar.svg?branch=master"></a>
+<a href="https://travis-ci.com/sushisharkjl/polybar"><img src="https://travis-ci.com/sushisharkjl/polybar.svg?branch=master"></a>
 <a href="https://polybar.readthedocs.io"><img src="https://readthedocs.org/projects/polybar/badge/?version=latest"></a>
 <a href="https://gitter.im/polybar/polybar"><img src="https://badges.gitter.im/polybar/polybar.svg"></a>
 <a href="https://codecov.io/gh/polybar/polybar/branch/master"><img src="https://codecov.io/gh/polybar/polybar/branch/master/graph/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## sushisharkjl/polybar
+
+This fork was created with the **sole** intent of allowing disconnected network interfaces to be kept alive in the internal/network module. It will only track upstream when I (the maintainer) decide to merge. Do not use this fork with the intent that it will perpetually track upstream.
+
 <p align="center">
   <img src="banner.png" alt="Polybar">
 </p>

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -217,8 +217,9 @@ namespace net {
    */
   bool network::test_interface() const {
     auto operstate = file_util::contents("/sys/class/net/" + m_interface + "/operstate");
-    bool up = operstate.compare(0, 2, "up") == 0;
-    return m_unknown_up ? (up || operstate.compare(0, 7, "unknown") == 0) : up;
+    bool up = operstate.compare(0, 4, "down") != 0;
+    return up;
+    // return m_unknown_up ? (up || operstate.compare(0, 7, "unknown") == 0) : up;
   }
 
   /**

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -282,11 +282,11 @@ namespace net {
    * Check current connection state
    */
   bool wired_network::connected() const {
-    if (!m_tuntap && !network::test_interface()) {
-      return false;
-    }
+    // if (!m_tuntap && !network::test_interface()) {
+    //   return false;
+    // }
 
-    else return true;
+    return network::test_interface();
 
     /*
     struct ethtool_value data {};

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -286,6 +286,9 @@ namespace net {
       return false;
     }
 
+    else return true;
+
+    /*
     struct ethtool_value data {};
     struct ifreq request {};
 
@@ -299,6 +302,7 @@ namespace net {
     }
 
     return data.data != 0;
+    */
   }
 
   /**

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -81,7 +81,10 @@ namespace modules {
     net::network* network =
         m_wireless ? static_cast<net::network*>(m_wireless.get()) : static_cast<net::network*>(m_wired.get());
 
+    printf("Network interface %s updated\n", m_interface.c_str());
+
     if (!network->query(m_accumulate)) {
+      printf("Disconnected %s\n", m_interface.c_str());
       m_log.warn("%s: Failed to query interface '%s', assuming disconnected", name(), m_interface);
       m_connected = false;
     } else {


### PR DESCRIPTION
Allows for smoother integration of external NICs eg. those found in docking stations. 

**Missing Interfaces**

Instead of ignoring interfaces which do not exist, we will keep polling them at each refresh of the module for tighter integration of hotswappable NICs.

**Unknown operstates**

We now mark all interfaces with operstates of not `down` as being "up".